### PR TITLE
Fix typo in sets level 4

### DIFF
--- a/src/game/sets/sets_level04.lean
+++ b/src/game/sets/sets_level04.lean
@@ -25,7 +25,7 @@ the same elements.
 In Lean's maths library this axiom is called `ext_iff`.
 
 ```
-lemma ext_diff : A = B ↔ ∀ x : X, x ∈ A ↔ x ∈ B
+lemma ext_iff : A = B ↔ ∀ x : X, x ∈ A ↔ x ∈ B
 ```
 -/
 


### PR DESCRIPTION
The explanatory text for sets level 4 has a confusing typo.